### PR TITLE
feat: Add GitHub Actions for PR checks and releases

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,0 +1,27 @@
+name: PR Check
+
+on: [pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # Needed to checkout the code
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest # or specify a version
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Compile check
+        run: bun run compile
+
+      - name: Build extension
+        run: bun run build

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,24 @@
+name: Release Please
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write # Allow to create/update PRs
+  pull-requests: write # Allow to create/update PRs
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/release-please-action@v4
+        with:
+          release-type: node # Assumes a node-style project for versioning and changelog
+          package-name: unofficial-wgu-extension # Matches the name in package.json
+          # You can add a GITHUB_TOKEN secret if needed, but it often works without for public repos
+          # token: ${{ secrets.GITHUB_TOKEN }}
+          # If you use a custom versioning scheme or changelog format, configure it here.
+          # For example, to include all commit types in the changelog:
+          # changelog-types: '[{"type":"feat","section":"Features","hidden":false},{"type":"fix","section":"Bug Fixes","hidden":false},{"type":"build","section":"Build System","hidden":false},{"type":"chore","section":"Chores","hidden":false},{"type":"ci","section":"Continuous Integration","hidden":false},{"type":"docs","section":"Documentation","hidden":false},{"type":"perf","section":"Performance Improvements","hidden":false},{"type":"refactor","section":"Refactors","hidden":false},{"type":"style","section":"Styles","hidden":false},{"type":"test","section":"Tests","hidden":false}]

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
 # WXT + React
 
+[![PR Check](https://github.com/GoogleChromeLabs/wxt-react-example/actions/workflows/pr-check.yml/badge.svg)](https://github.com/GoogleChromeLabs/wxt-react-example/actions/workflows/pr-check.yml)
+[![Release Please](https://github.com/GoogleChromeLabs/wxt-react-example/actions/workflows/release-please.yml/badge.svg)](https://github.com/GoogleChromeLabs/wxt-react-example/actions/workflows/release-please.yml)
+
 This template should help get you started developing with React in WXT.


### PR DESCRIPTION
Adds two GitHub Actions workflows:

1.  `pr-check.yml`: This workflow runs on every pull request. It installs dependencies, compiles the TypeScript code, and builds the extension to ensure basic code integrity and catch build errors.

2.  `release-please.yml`: This workflow runs on pushes to the main branch. It uses the `google-github-actions/release-please-action` to automate the release process. It will create or update a release pull request based on conventional commit messages. Merging this PR will trigger the creation of a GitHub release and tag.

Also updated README.md to include badges for these new workflows. You may need to update the repository owner and name in the badge URLs in README.md if the placeholder is incorrect.