### PR TITLE
fix(functions): align CORS allowlist with documented policy

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -12,7 +12,7 @@
     "bash -c 'cd graphql-client && npx eslint --fix $(printf \"%s\\n\" \"$@\" | sed \"s:^graphql-client/::\")' --"
   ],
   "functions/**/*.{ts,js}": [
-    "bash -c 'cd functions && npx eslint --fix $(printf \"%s\\n\" \"$@\" | sed \"s:^functions/::\")' --"
+    "bash -c 'cd functions && pnpm exec eslint --fix $(printf \"%s\\n\" \"$@\" | sed \"s:^functions/::\")' --"
   ],
   "*.{json,yml,yaml,md}": [
     "echo 'Non-code files validated. Type checking happens separately.'"

--- a/functions/CLAUDE.md
+++ b/functions/CLAUDE.md
@@ -141,16 +141,22 @@ const allowedQueries = require('./allowlist.json');
 - **Storage**: Firestore rate limit tracking
 
 ### CORS Policy
-```typescript
-const corsOptions = {
-  origin: [
-    /^https:\/\/.*\.wgu\.edu$/,
-    /^chrome-extension:\/\/[a-z]{32}$/,
-    /^moz-extension:\/\/[a-f0-9-]{36}$/
-  ],
-  credentials: true
-};
+
+Implemented in `src/lib/cors.ts` via `getAllowedOrigins()` (default allowlist) and `isOriginAllowed()` (regex-aware match). Default allowlist:
+
+```ts
+[
+  /^https:\/\/.*\.wgu\.edu$/,           // any wgu.edu subdomain
+  /^chrome-extension:\/\/[a-z]{32}$/,   // Chrome extension origins
+  /^moz-extension:\/\/[a-f0-9-]{36}$/,  // Firefox extension origins
+  "https://wgu-extension.web.app",      // docs site (Firebase Hosting)
+  "https://wgu-extension.firebaseapp.com",
+  "http://localhost:5173",              // local dev
+  "http://127.0.0.1:5173",
+]
 ```
+
+The `ALLOWED_ORIGINS` environment variable overrides the defaults entirely with a comma-separated list of exact-match strings (regex is not supported in the env override).
 
 ## Data Architecture
 

--- a/functions/src/http/graphql-public.ts
+++ b/functions/src/http/graphql-public.ts
@@ -5,7 +5,7 @@ import depthLimit from "graphql-depth-limit";
 import {getComplexity, simpleEstimator} from "graphql-query-complexity";
 import {publicTypeDefs} from "../graphql/public-schema.js";
 import {publicResolvers} from "../graphql/public-resolvers.js";
-import {getAllowedOrigins} from "../lib/cors.js";
+import {getAllowedOrigins, isOriginAllowed} from "../lib/cors.js";
 import * as allowlist from "../graphql/allowlist.json";
 
 const schema = buildSchema(publicTypeDefs);
@@ -80,7 +80,8 @@ const yoga = createYoga({
 
         // CORS handling for GET requests
         const origin = request.headers.get("origin");
-        if (origin && !allowedOrigins.includes(origin) && process.env.NODE_ENV === "production") {
+        const isProd = process.env.NODE_ENV === "production";
+        if (origin && isProd && !isOriginAllowed(origin, allowedOrigins)) {
           return endResponse(
             new fetchAPI.Response(
               JSON.stringify({

--- a/functions/src/lib/cors.ts
+++ b/functions/src/lib/cors.ts
@@ -1,9 +1,18 @@
-export function getAllowedOrigins(raw: string | undefined): string[] {
+import type {Request} from "firebase-functions/v2/https";
+import type {Response} from "express";
+
+export type AllowedOrigin = string | RegExp;
+
+export function getAllowedOrigins(raw: string | undefined): AllowedOrigin[] {
   if (raw && raw.trim().length > 0) {
     return raw.split(",").map((s) => s.trim()).filter(Boolean);
   }
-  // Default origins: production site + local development
+  // Default origins: documented policy + Firebase Hosting (docs site) + local dev.
+  // The env override (ALLOWED_ORIGINS) accepts comma-separated exact-match strings only.
   return [
+    /^https:\/\/.*\.wgu\.edu$/,
+    /^chrome-extension:\/\/[a-z]{32}$/,
+    /^moz-extension:\/\/[a-f0-9-]{36}$/,
     "https://wgu-extension.web.app",
     "https://wgu-extension.firebaseapp.com",
     "http://localhost:5173",
@@ -11,12 +20,19 @@ export function getAllowedOrigins(raw: string | undefined): string[] {
   ];
 }
 
-import type {Request} from "firebase-functions/v2/https";
-import type {Response} from "express";
+export function isOriginAllowed(
+  origin: string | undefined,
+  allowed: AllowedOrigin[]
+): boolean {
+  if (!origin) return false;
+  return allowed.some((rule) =>
+    typeof rule === "string" ? rule === origin : rule.test(origin)
+  );
+}
 
-export function setCors(req: Request, res: Response, allowedOrigins: string[]) {
+export function setCors(req: Request, res: Response, allowedOrigins: AllowedOrigin[]) {
   const origin = (req.headers?.origin as string | undefined) ?? "";
-  if (origin && allowedOrigins.includes(origin)) {
+  if (isOriginAllowed(origin, allowedOrigins)) {
     res.setHeader("Access-Control-Allow-Origin", origin);
   }
   res.setHeader("Vary", "Origin");

--- a/functions/src/test/cors.test.ts
+++ b/functions/src/test/cors.test.ts
@@ -1,0 +1,153 @@
+import {describe, expect, test} from "@jest/globals";
+import type {Request} from "firebase-functions/v2/https";
+import type {Response} from "express";
+import {getAllowedOrigins, isOriginAllowed, setCors} from "../lib/cors";
+
+function makeReq(origin?: string): Request {
+  return {headers: origin ? {origin} : {}} as unknown as Request;
+}
+
+function makeRes(): {res: Response; headers: Record<string, string>} {
+  const headers: Record<string, string> = {};
+  const res = {
+    setHeader(name: string, value: string) {
+      headers[name] = value;
+    },
+  } as unknown as Response;
+  return {res, headers};
+}
+
+describe("getAllowedOrigins", () => {
+  test("returns documented + dev defaults when env is unset", () => {
+    const defaults = getAllowedOrigins(undefined);
+    expect(defaults).toEqual([
+      /^https:\/\/.*\.wgu\.edu$/,
+      /^chrome-extension:\/\/[a-z]{32}$/,
+      /^moz-extension:\/\/[a-f0-9-]{36}$/,
+      "https://wgu-extension.web.app",
+      "https://wgu-extension.firebaseapp.com",
+      "http://localhost:5173",
+      "http://127.0.0.1:5173",
+    ]);
+  });
+
+  test("returns defaults when env is empty/whitespace", () => {
+    expect(getAllowedOrigins("")).toEqual(getAllowedOrigins(undefined));
+    expect(getAllowedOrigins("   ")).toEqual(getAllowedOrigins(undefined));
+  });
+
+  test("env override returns user strings only (no defaults)", () => {
+    const result = getAllowedOrigins("https://a.example, https://b.example");
+    expect(result).toEqual(["https://a.example", "https://b.example"]);
+  });
+
+  test("env override trims and drops empty entries", () => {
+    expect(getAllowedOrigins(" https://x.example ,, https://y.example ")).toEqual([
+      "https://x.example",
+      "https://y.example",
+    ]);
+  });
+});
+
+describe("isOriginAllowed (default policy)", () => {
+  const defaults = getAllowedOrigins(undefined);
+
+  test("rejects empty/undefined origin", () => {
+    expect(isOriginAllowed(undefined, defaults)).toBe(false);
+    expect(isOriginAllowed("", defaults)).toBe(false);
+  });
+
+  test("accepts wgu.edu subdomains", () => {
+    expect(isOriginAllowed("https://my.wgu.edu", defaults)).toBe(true);
+    expect(isOriginAllowed("https://tasks.wgu.edu", defaults)).toBe(true);
+    expect(isOriginAllowed("https://wguconnect.wgu.edu", defaults)).toBe(true);
+  });
+
+  test("rejects bare wgu.edu (regex requires a subdomain)", () => {
+    expect(isOriginAllowed("https://wgu.edu", defaults)).toBe(false);
+  });
+
+  test("rejects http (non-TLS) wgu.edu", () => {
+    expect(isOriginAllowed("http://my.wgu.edu", defaults)).toBe(false);
+  });
+
+  test("rejects look-alike domains", () => {
+    expect(isOriginAllowed("https://wgu.edu.evil.com", defaults)).toBe(false);
+    expect(isOriginAllowed("https://evilwgu.edu", defaults)).toBe(false);
+    expect(isOriginAllowed("https://evil.com", defaults)).toBe(false);
+  });
+
+  test("accepts chrome-extension origin with 32-char id", () => {
+    const id = "a".repeat(32);
+    expect(isOriginAllowed(`chrome-extension://${id}`, defaults)).toBe(true);
+  });
+
+  test("rejects malformed chrome-extension origins", () => {
+    expect(isOriginAllowed(`chrome-extension://${"a".repeat(31)}`, defaults)).toBe(false);
+    expect(isOriginAllowed(`chrome-extension://${"a".repeat(33)}`, defaults)).toBe(false);
+    expect(isOriginAllowed(`chrome-extension://${"A".repeat(32)}`, defaults)).toBe(false);
+  });
+
+  test("accepts moz-extension origin with UUID", () => {
+    expect(
+      isOriginAllowed("moz-extension://12345678-1234-1234-1234-123456789abc", defaults)
+    ).toBe(true);
+  });
+
+  test("rejects malformed moz-extension origins", () => {
+    expect(isOriginAllowed("moz-extension://not-a-uuid", defaults)).toBe(false);
+    // Wrong length
+    expect(isOriginAllowed("moz-extension://12345678-1234-1234-1234-123456789ab", defaults)).toBe(false);
+    // Uppercase / out-of-charset characters
+    expect(isOriginAllowed("moz-extension://12345678-1234-1234-1234-123456789ABC", defaults)).toBe(false);
+    expect(isOriginAllowed("moz-extension://gggggggg-gggg-gggg-gggg-gggggggggggg", defaults)).toBe(false);
+  });
+
+  test("accepts Firebase Hosting origins (docs site)", () => {
+    expect(isOriginAllowed("https://wgu-extension.web.app", defaults)).toBe(true);
+    expect(isOriginAllowed("https://wgu-extension.firebaseapp.com", defaults)).toBe(true);
+  });
+
+  test("accepts localhost dev origins", () => {
+    expect(isOriginAllowed("http://localhost:5173", defaults)).toBe(true);
+    expect(isOriginAllowed("http://127.0.0.1:5173", defaults)).toBe(true);
+  });
+
+  test("rejects other localhost ports", () => {
+    expect(isOriginAllowed("http://localhost:3000", defaults)).toBe(false);
+  });
+});
+
+describe("setCors", () => {
+  test("echoes Access-Control-Allow-Origin only when origin is allowed", () => {
+    const allowed = getAllowedOrigins(undefined);
+    const {res, headers} = makeRes();
+
+    setCors(makeReq("https://my.wgu.edu"), res, allowed);
+
+    expect(headers["Access-Control-Allow-Origin"]).toBe("https://my.wgu.edu");
+    expect(headers["Vary"]).toBe("Origin");
+    expect(headers["Access-Control-Allow-Methods"]).toBe("POST, OPTIONS");
+    expect(headers["Access-Control-Allow-Headers"]).toContain("Content-Type");
+  });
+
+  test("never sets Access-Control-Allow-Origin for disallowed origin", () => {
+    const allowed = getAllowedOrigins(undefined);
+    const {res, headers} = makeRes();
+
+    setCors(makeReq("https://evil.com"), res, allowed);
+
+    expect(headers["Access-Control-Allow-Origin"]).toBeUndefined();
+    expect(headers["Vary"]).toBe("Origin");
+  });
+
+  test("does not set Access-Control-Allow-Origin when origin header missing", () => {
+    const allowed = getAllowedOrigins(undefined);
+    const {res, headers} = makeRes();
+
+    setCors(makeReq(undefined), res, allowed);
+
+    expect(headers["Access-Control-Allow-Origin"]).toBeUndefined();
+    expect(headers["Vary"]).toBe("Origin");
+  });
+});


### PR DESCRIPTION
The default allowlist in `functions/src/lib/cors.ts` only matched a few
exact-string origins, while `functions/CLAUDE.md` documented regex-based
matching for `*.wgu.edu`, `chrome-extension://`, and `moz-extension://`.
As a result the extension's own origins and any `*.wgu.edu` site were
silently blocked, while contributors trusted the docs.

- `lib/cors.ts`: defaults are now a regex+string union covering the
  documented policy plus Firebase Hosting (docs site) and localhost dev
  origins; add `isOriginAllowed` helper; `setCors` matches via helper.
- `http/graphql-public.ts`: replace `Array.includes` with
  `isOriginAllowed`.
- `functions/CLAUDE.md`: rewrite CORS Policy section to reflect the real
  defaults and document the `ALLOWED_ORIGINS` env override.
- `test/cors.test.ts`: new unit tests covering wgu.edu subdomains,
  extension origins, hosting origins, dev origins, env override, and
  `setCors` behavior.
- `.lintstagedrc.json`: switch the functions hook from `npx eslint` to
  `pnpm exec eslint`. The repo's local eslint is v8.57.1, but `npx` was
  resolving to a global v10 that rejects the `.eslintrc` config; this
  was blocking the pre-commit hook.

Closes #50

https://claude.ai/code/session_0171cBevq1gBJcnpHfFdcgza