### PR TITLE
fix(functions): use Yoga built-in CORS + tighten chrome-extension regex

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,15 +1,15 @@
 {
   "extension/**/*.{ts,tsx}": [
-    "bash -c 'cd extension && npx eslint --fix $(printf \"%s\\n\" \"$@\" | sed \"s:^extension/::\")' --"
+    "bash -c 'cd extension && pnpm exec eslint --fix $(printf \"%s\\n\" \"$@\" | sed \"s:^extension/::\")' --"
   ],
   "site/**/*.{ts,tsx}": [
-    "bash -c 'cd site && npx eslint --fix $(printf \"%s\\n\" \"$@\" | sed \"s:^site/::\")' --"
+    "bash -c 'cd site && pnpm exec eslint --fix $(printf \"%s\\n\" \"$@\" | sed \"s:^site/::\")' --"
   ],
   "data/**/*.{ts,js}": [
-    "bash -c 'cd data && npx eslint --fix $(printf \"%s\\n\" \"$@\" | sed \"s:^data/::\")' --"
+    "bash -c 'cd data && pnpm exec eslint --fix $(printf \"%s\\n\" \"$@\" | sed \"s:^data/::\")' --"
   ],
   "graphql-client/**/*.{ts,js}": [
-    "bash -c 'cd graphql-client && npx eslint --fix $(printf \"%s\\n\" \"$@\" | sed \"s:^graphql-client/::\")' --"
+    "bash -c 'cd graphql-client && pnpm exec eslint --fix $(printf \"%s\\n\" \"$@\" | sed \"s:^graphql-client/::\")' --"
   ],
   "functions/**/*.{ts,js}": [
     "bash -c 'cd functions && pnpm exec eslint --fix $(printf \"%s\\n\" \"$@\" | sed \"s:^functions/::\")' --"

--- a/functions/CLAUDE.md
+++ b/functions/CLAUDE.md
@@ -147,7 +147,7 @@ Implemented in `src/lib/cors.ts` via `getAllowedOrigins()` (default allowlist) a
 ```ts
 [
   /^https:\/\/.*\.wgu\.edu$/,           // any wgu.edu subdomain
-  /^chrome-extension:\/\/[a-z]{32}$/,   // Chrome extension origins
+  /^chrome-extension:\/\/[a-p]{32}$/,   // Chrome extension origins (IDs use a-p only)
   /^moz-extension:\/\/[a-f0-9-]{36}$/,  // Firefox extension origins
   "https://wgu-extension.web.app",      // docs site (Firebase Hosting)
   "https://wgu-extension.firebaseapp.com",

--- a/functions/src/http/graphql-public.ts
+++ b/functions/src/http/graphql-public.ts
@@ -25,6 +25,21 @@ function validateVariables(hash: string, variables: unknown) {
 const yoga = createYoga({
   schema,
   graphiql: false, // Disable GraphiQL in production
+  // CORS: Yoga's built-in plugin handles preflight (OPTIONS) and adds headers
+  // to successful responses. We use the factory form so origin matching can
+  // run through `isOriginAllowed` (regex-aware). Returning `false` for a
+  // disallowed origin omits CORS headers and the browser blocks the response.
+  cors: (request) => {
+    const origin = request.headers.get("origin");
+    if (!origin) return false;
+    const isProd = process.env.NODE_ENV === "production";
+    if (isProd && !isOriginAllowed(origin, allowedOrigins)) return false;
+    return {
+      origin: [origin],
+      methods: ["GET", "OPTIONS"],
+      allowedHeaders: ["Content-Type", "Authorization"],
+    };
+  },
   context: async ({request}) => {
     // Extract user from Authorization header if present
     const authHeader = request.headers.get("authorization");
@@ -60,7 +75,9 @@ const yoga = createYoga({
   plugins: [
     {
       onRequest({request, fetchAPI, endResponse}) {
-        // Only allow GET requests
+        // Public endpoint only accepts GET (queries via persisted hashes).
+        // OPTIONS preflight is handled by Yoga's built-in CORS plugin (registered
+        // via the `cors` option above) and short-circuits before reaching here.
         if (request.method !== "GET") {
           return endResponse(
             new fetchAPI.Response(
@@ -69,26 +86,6 @@ const yoga = createYoga({
               }),
               {
                 status: 405,
-                headers: {
-                  "Content-Type": "application/json",
-                  "Access-Control-Allow-Origin": "*",
-                },
-              }
-            )
-          );
-        }
-
-        // CORS handling for GET requests
-        const origin = request.headers.get("origin");
-        const isProd = process.env.NODE_ENV === "production";
-        if (origin && isProd && !isOriginAllowed(origin, allowedOrigins)) {
-          return endResponse(
-            new fetchAPI.Response(
-              JSON.stringify({
-                errors: [{message: "Origin not allowed"}],
-              }),
-              {
-                status: 403,
                 headers: {"Content-Type": "application/json"},
               }
             )
@@ -153,7 +150,7 @@ const yoga = createYoga({
 
 export const publicApi = onRequest(
   {
-    cors: false, // We handle CORS manually
+    cors: false, // Yoga's built-in CORS plugin handles preflight + headers
     memory: "512MiB",
     timeoutSeconds: 10,
   },

--- a/functions/src/http/graphql-public.ts
+++ b/functions/src/http/graphql-public.ts
@@ -37,7 +37,7 @@ const yoga = createYoga({
     return {
       origin: [origin],
       methods: ["GET", "OPTIONS"],
-      allowedHeaders: ["Content-Type", "Authorization"],
+      allowedHeaders: ["Content-Type", "Authorization", "X-Extension-Version", "X-Client"],
     };
   },
   context: async ({request}) => {

--- a/functions/src/lib/cors.ts
+++ b/functions/src/lib/cors.ts
@@ -11,7 +11,7 @@ export function getAllowedOrigins(raw: string | undefined): AllowedOrigin[] {
   // The env override (ALLOWED_ORIGINS) accepts comma-separated exact-match strings only.
   return [
     /^https:\/\/.*\.wgu\.edu$/,
-    /^chrome-extension:\/\/[a-z]{32}$/,
+    /^chrome-extension:\/\/[a-p]{32}$/,
     /^moz-extension:\/\/[a-f0-9-]{36}$/,
     "https://wgu-extension.web.app",
     "https://wgu-extension.firebaseapp.com",
@@ -25,9 +25,12 @@ export function isOriginAllowed(
   allowed: AllowedOrigin[]
 ): boolean {
   if (!origin) return false;
-  return allowed.some((rule) =>
-    typeof rule === "string" ? rule === origin : rule.test(origin)
-  );
+  return allowed.some((rule) => {
+    if (typeof rule === "string") return rule === origin;
+    // Reset lastIndex so the helper is safe with g/y-flagged regexes.
+    rule.lastIndex = 0;
+    return rule.test(origin);
+  });
 }
 
 export function setCors(req: Request, res: Response, allowedOrigins: AllowedOrigin[]) {

--- a/functions/src/test/cors.test.ts
+++ b/functions/src/test/cors.test.ts
@@ -22,7 +22,7 @@ describe("getAllowedOrigins", () => {
     const defaults = getAllowedOrigins(undefined);
     expect(defaults).toEqual([
       /^https:\/\/.*\.wgu\.edu$/,
-      /^chrome-extension:\/\/[a-z]{32}$/,
+      /^chrome-extension:\/\/[a-p]{32}$/,
       /^moz-extension:\/\/[a-f0-9-]{36}$/,
       "https://wgu-extension.web.app",
       "https://wgu-extension.firebaseapp.com",
@@ -86,6 +86,9 @@ describe("isOriginAllowed (default policy)", () => {
     expect(isOriginAllowed(`chrome-extension://${"a".repeat(31)}`, defaults)).toBe(false);
     expect(isOriginAllowed(`chrome-extension://${"a".repeat(33)}`, defaults)).toBe(false);
     expect(isOriginAllowed(`chrome-extension://${"A".repeat(32)}`, defaults)).toBe(false);
+    // Real Chrome IDs are limited to a-p; characters outside that range must be rejected.
+    expect(isOriginAllowed(`chrome-extension://${"q".repeat(32)}`, defaults)).toBe(false);
+    expect(isOriginAllowed(`chrome-extension://${"z".repeat(32)}`, defaults)).toBe(false);
   });
 
   test("accepts moz-extension origin with UUID", () => {
@@ -115,6 +118,17 @@ describe("isOriginAllowed (default policy)", () => {
 
   test("rejects other localhost ports", () => {
     expect(isOriginAllowed("http://localhost:3000", defaults)).toBe(false);
+  });
+
+  test("is idempotent across calls when allowlist contains a stateful regex", () => {
+    // Caller-supplied `g`-flagged regex would have stateful lastIndex; the helper
+    // should reset it so repeated calls return the same result.
+    const stateful = /^https:\/\/example\.com$/g;
+    const rules: typeof defaults = [stateful];
+
+    expect(isOriginAllowed("https://example.com", rules)).toBe(true);
+    expect(isOriginAllowed("https://example.com", rules)).toBe(true);
+    expect(isOriginAllowed("https://example.com", rules)).toBe(true);
   });
 });
 


### PR DESCRIPTION
Follow-up to #54 addressing the post-merge review feedback from gemini-code-assist and Copilot.

## Summary

- **`graphql-public.ts`** — replace the manual CORS plugin with Yoga's built-in `cors` factory. The previous code never set `Access-Control-Allow-Origin` on successful responses and rejected `OPTIONS` preflight with 405, so any cross-origin request (including the browser extension and any `*.wgu.edu` site) was effectively blocked despite passing the allowlist check. The factory delegates origin matching to `isOriginAllowed` so the regex defaults still apply, returns `false` for disallowed origins (no CORS headers — browser blocks), and lets Yoga handle `Access-Control-Allow-Headers: Authorization` for preflight. Allowlist enforcement is gated on `NODE_ENV === "production"` (preserved from the prior implementation) so local dev/emulator traffic from arbitrary origins still works.
- **`lib/cors.ts`** — tighten chrome-extension regex from `[a-z]{32}` to `[a-p]{32}` (real Chrome extension IDs only use the `a`–`p` alphabet). Add defensive `rule.lastIndex = 0` in `isOriginAllowed` so caller-supplied `g`/`y`-flagged regexes don't break idempotency.
- **`CLAUDE.md`** — sync documented chrome-extension pattern.
- **`test/cors.test.ts`** — assert tightened defaults; reject `[q-z]` characters; add idempotency test for stateful regex.
- **`.lintstagedrc.json`** — extend the `npx eslint` → `pnpm exec eslint` fix from #54 to the remaining workspace hooks (extension, site, data, graphql-client).

## Test plan

- [x] `pnpm --filter=functions run typecheck` — clean
- [x] `pnpm --filter=functions run test:unit` — 47 passed (1 new), 1 pre-existing skip
- [x] `pnpm --filter=functions run lint` — 0 errors (only pre-existing warnings)
- [ ] Manual smoke (recommended): start `pnpm run dev:functions` and confirm the happy paths work:
  - GET `/publicApi?hash=...` from a `chrome-extension://aaaa…` (32 chars `a`-`p`) origin returns CORS headers and the GraphQL response.
  - OPTIONS preflight from the same origin returns 204 with `Access-Control-Allow-Origin: <origin>` and `Access-Control-Allow-Headers` listing `Content-Type, Authorization, X-Extension-Version, X-Client`.
  - **Note:** the local emulator runs without `NODE_ENV=production`, so the allowlist is not enforced — any origin is echoed back. To validate disallowed-origin rejection (e.g. `https://evil.com` → no `Access-Control-Allow-Origin` header), run with `NODE_ENV=production pnpm run dev:functions` or rely on the unit tests for `isOriginAllowed`, which cover the rejection logic directly.

Closes the high-priority gemini comment about manual CORS being incomplete and the Copilot comments about regex permissiveness and stateful regex hardening on #54.

https://claude.ai/code/session_0171cBevq1gBJcnpHfFdcgza