### PR TITLE
fix(rules): remove broken automated bypass in suggestions create rule

### DIFF
--- a/firebase/firestore-admin.rules
+++ b/firebase/firestore-admin.rules
@@ -28,7 +28,7 @@ service cloud.firestore {
       // Anyone authenticated can read suggestions
       allow read: if isAuthenticated();
       
-      // Anyone authenticated can create suggestions
+      // Authenticated users can create suggestions only on their own behalf.
       // Ensure submittedBy.userId matches the authenticated user.
       // Automated/bot suggestions are written by Cloud Functions via the
       // Admin SDK (which bypasses these rules), not by client callers.

--- a/firebase/firestore-admin.rules
+++ b/firebase/firestore-admin.rules
@@ -29,10 +29,11 @@ service cloud.firestore {
       allow read: if isAuthenticated();
       
       // Anyone authenticated can create suggestions
-      allow create: if isAuthenticated() && 
-        // Ensure submittedBy.userId matches the authenticated user
-        (request.resource.data.submittedBy.userId == request.auth.uid ||
-         resource.data.submittedBy.source == 'automated');
+      // Ensure submittedBy.userId matches the authenticated user.
+      // Automated/bot suggestions are written by Cloud Functions via the
+      // Admin SDK (which bypasses these rules), not by client callers.
+      allow create: if isAuthenticated() &&
+        request.resource.data.submittedBy.userId == request.auth.uid;
       
       // Only admins can update suggestions (for review process)
       allow update: if isAdmin();

--- a/functions/package.json
+++ b/functions/package.json
@@ -79,6 +79,7 @@
     "zod": "^4.0.17"
   },
   "devDependencies": {
+    "@firebase/rules-unit-testing": "^5.0.0",
     "@graphql-tools/schema": "^10.0.0",
     "@jest/globals": "^30.0.5",
     "@types/body-parser": "^1.19.6",
@@ -93,6 +94,7 @@
     "eslint": "^8.57.0",
     "eslint-config-google": "^0.14.0",
     "eslint-plugin-import": "^2.25.4",
+    "firebase": "^12.0.0",
     "firebase-functions-test": "^3.1.0",
     "jest": "^30.0.5",
     "jest-junit": "^16.0.0",

--- a/functions/src/test/firestore-admin-rules.integration.test.ts
+++ b/functions/src/test/firestore-admin-rules.integration.test.ts
@@ -1,4 +1,4 @@
-import {describe, expect, test, beforeAll, afterAll, beforeEach} from "@jest/globals";
+import {describe, test, beforeAll, afterAll, beforeEach} from "@jest/globals";
 import * as fs from "fs";
 import * as path from "path";
 import {
@@ -92,10 +92,9 @@ describe("firestore-admin.rules: /suggestions create", () => {
     );
   });
 
-  test("denies create when submittedBy.source is 'automated' and userId matches auth.uid is still permitted (source field is not authoritative)", async () => {
-    // Even when source is 'automated', the rule only depends on
-    // submittedBy.userId == auth.uid. Setting source should not change
-    // the outcome relative to a normal create by the same user.
+  test("allows create when submittedBy.source is 'automated' if userId matches auth.uid", async () => {
+    // The rule depends only on submittedBy.userId == auth.uid; the
+    // self-declared `source` field is not authoritative.
     const ctx = testEnv.authenticatedContext("user-alice");
     const ref = doc(ctx.firestore(), SUGGESTIONS, "suggestion-4");
 

--- a/functions/src/test/firestore-admin-rules.integration.test.ts
+++ b/functions/src/test/firestore-admin-rules.integration.test.ts
@@ -1,0 +1,139 @@
+import {describe, expect, test, beforeAll, afterAll, beforeEach} from "@jest/globals";
+import * as fs from "fs";
+import * as path from "path";
+import {
+  assertFails,
+  assertSucceeds,
+  initializeTestEnvironment,
+  RulesTestEnvironment,
+} from "@firebase/rules-unit-testing";
+import {setDoc, doc} from "firebase/firestore";
+
+const RULES_PATH = path.resolve(__dirname, "../../../firebase/firestore-admin.rules");
+
+const SUGGESTIONS = "suggestions";
+
+function buildSuggestion(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    type: "discord_server",
+    submittedAt: new Date().toISOString(),
+    submittedBy: {
+      userId: "user-alice",
+      source: "manual",
+    },
+    payload: {name: "Example Discord"},
+    status: "pending",
+    ...overrides,
+  };
+}
+
+describe("firestore-admin.rules: /suggestions create", () => {
+  let testEnv: RulesTestEnvironment;
+
+  beforeAll(async () => {
+    testEnv = await initializeTestEnvironment({
+      projectId: "demo-admin-rules",
+      firestore: {
+        rules: fs.readFileSync(RULES_PATH, "utf8"),
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await testEnv.cleanup();
+  });
+
+  beforeEach(async () => {
+    await testEnv.clearFirestore();
+  });
+
+  test("allows authenticated user to create when submittedBy.userId matches auth.uid", async () => {
+    const ctx = testEnv.authenticatedContext("user-alice");
+    const ref = doc(ctx.firestore(), SUGGESTIONS, "suggestion-1");
+
+    await assertSucceeds(
+      setDoc(
+        ref,
+        buildSuggestion({
+          submittedBy: {userId: "user-alice", source: "manual"},
+        })
+      )
+    );
+  });
+
+  test("denies authenticated user when submittedBy.userId does not match auth.uid", async () => {
+    const ctx = testEnv.authenticatedContext("user-alice");
+    const ref = doc(ctx.firestore(), SUGGESTIONS, "suggestion-2");
+
+    await assertFails(
+      setDoc(
+        ref,
+        buildSuggestion({
+          submittedBy: {userId: "user-bob", source: "manual"},
+        })
+      )
+    );
+  });
+
+  test("denies impersonation even when submittedBy.source is 'automated'", async () => {
+    // Regression test for the removed `source == 'automated'` bypass.
+    // A logged-in user must not be able to write a suggestion claiming
+    // another user's uid by setting submittedBy.source to 'automated'.
+    const ctx = testEnv.authenticatedContext("user-alice");
+    const ref = doc(ctx.firestore(), SUGGESTIONS, "suggestion-3");
+
+    await assertFails(
+      setDoc(
+        ref,
+        buildSuggestion({
+          submittedBy: {userId: "user-bob", source: "automated"},
+        })
+      )
+    );
+  });
+
+  test("denies create when submittedBy.source is 'automated' and userId matches auth.uid is still permitted (source field is not authoritative)", async () => {
+    // Even when source is 'automated', the rule only depends on
+    // submittedBy.userId == auth.uid. Setting source should not change
+    // the outcome relative to a normal create by the same user.
+    const ctx = testEnv.authenticatedContext("user-alice");
+    const ref = doc(ctx.firestore(), SUGGESTIONS, "suggestion-4");
+
+    await assertSucceeds(
+      setDoc(
+        ref,
+        buildSuggestion({
+          submittedBy: {userId: "user-alice", source: "automated"},
+        })
+      )
+    );
+  });
+
+  test("denies unauthenticated create even when payload userId is set", async () => {
+    const ctx = testEnv.unauthenticatedContext();
+    const ref = doc(ctx.firestore(), SUGGESTIONS, "suggestion-5");
+
+    await assertFails(
+      setDoc(
+        ref,
+        buildSuggestion({
+          submittedBy: {userId: "user-alice", source: "manual"},
+        })
+      )
+    );
+  });
+
+  test("denies unauthenticated create with submittedBy.source == 'automated'", async () => {
+    const ctx = testEnv.unauthenticatedContext();
+    const ref = doc(ctx.firestore(), SUGGESTIONS, "suggestion-6");
+
+    await assertFails(
+      setDoc(
+        ref,
+        buildSuggestion({
+          submittedBy: {userId: "anyone", source: "automated"},
+        })
+      )
+    );
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -230,6 +230,9 @@ importers:
         specifier: ^4.0.17
         version: 4.1.12
     devDependencies:
+      '@firebase/rules-unit-testing':
+        specifier: ^5.0.0
+        version: 5.0.0(firebase@12.4.0)
       '@graphql-tools/schema':
         specifier: ^10.0.0
         version: 10.0.25(graphql@16.11.0)
@@ -272,6 +275,9 @@ importers:
       eslint-plugin-import:
         specifier: ^2.25.4
         version: 2.32.0(@typescript-eslint/parser@8.47.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)
+      firebase:
+        specifier: ^12.0.0
+        version: 12.4.0
       firebase-functions-test:
         specifier: ^3.1.0
         version: 3.4.1(firebase-admin@13.5.0)(firebase-functions@7.0.5(@apollo/server@5.1.0(graphql@16.11.0))(@as-integrations/express4@1.1.2(@apollo/server@5.1.0(graphql@16.11.0))(express@4.21.2))(firebase-admin@13.5.0)(graphql@16.11.0))(jest@30.2.0(@types/node@22.18.13)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.18.13)(typescript@5.9.3)))
@@ -1282,6 +1288,12 @@ packages:
     peerDependencies:
       '@firebase/app': 0.x
 
+  '@firebase/rules-unit-testing@5.0.0':
+    resolution: {integrity: sha512-C6+d3Msgjnqay2ml663ChvKYoD8VsQ+TIa0e+fGq0LFC0CKSPlacT1EVGL/ryo6Rc+wFs7Fpqz3fRlYdUEa2bA==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      firebase: ^12.0.0
+
   '@firebase/storage-compat@0.4.0':
     resolution: {integrity: sha512-vDzhgGczr1OfcOy285YAPur5pWDEvD67w4thyeCUh6Ys0izN9fNYtA1MJERmNBfqjqu0lg0FM5GLbw0Il21M+g==}
     engines: {node: '>=20.0.0'}
@@ -1496,78 +1508,92 @@ packages:
     resolution: {integrity: sha512-I4RxkXU90cpufazhGPyVujYwfIm9Nk1QDEmiIsaPwdnm013F7RIceaCc87kAH+oUB1ezqEvC6ga4m7MSlqsJvQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.3':
     resolution: {integrity: sha512-x1uE93lyP6wEwGvgAIV0gP6zmaL/a0tGzJs/BIDDG0zeBhMnuUPm7ptxGhUbcGs4okDJrk4nxgrmxpib9g6HpA==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.3':
     resolution: {integrity: sha512-Y2T7IsQvJLMCBM+pmPbM3bKT/yYJvVtLJGfCs4Sp95SjvnFIjynbjzsa7dY1fRJX45FTSfDksbTp6AGWudiyCg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.3':
     resolution: {integrity: sha512-RgWrs/gVU7f+K7P+KeHFaBAJlNkD1nIZuVXdQv6S+fNA6syCcoboNjsV2Pou7zNlVdNQoQUpQTk8SWDHUA3y/w==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.3':
     resolution: {integrity: sha512-3JU7LmR85K6bBiRzSUc/Ff9JBVIFVvq6bomKE0e63UXGeRw2HPVEjoJke1Yx+iU4rL7/7kUjES4dZ/81Qjhyxg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.3':
     resolution: {integrity: sha512-F9q83RZ8yaCwENw1GieztSfj5msz7GGykG/BA+MOUefvER69K/ubgFHNeSyUu64amHIYKGDs4sRCMzXVj8sEyw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.3':
     resolution: {integrity: sha512-U5PUY5jbc45ANM6tSJpsgqmBF/VsL6LnxJmIf11kB7J5DctHgqm0SkuXzVWtIY90GnJxKnC/JT251TDnk1fu/g==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.4':
     resolution: {integrity: sha512-YXU1F/mN/Wu786tl72CyJjP/Ngl8mGHN1hST4BGl+hiW5jhCnV2uRVTNOcaYPs73NeT/H8Upm3y9582JVuZHrQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.4':
     resolution: {integrity: sha512-Xyam4mlqM0KkTHYVSuc6wXRmM7LGN0P12li03jAnZ3EJWZqj83+hi8Y9UxZUbxsgsK1qOEwg7O0Bc0LjqQVtxA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.4':
     resolution: {integrity: sha512-F4PDtF4Cy8L8hXA2p3TO6s4aDt93v+LKmpcYFLAVdkkD3hSxZzee0rh6/+94FpAynsuMpLX5h+LRsSG3rIciUQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.4':
     resolution: {integrity: sha512-qVrZKE9Bsnzy+myf7lFKvng6bQzhNUAYcVORq2P7bDlvmF6u2sCmK2KyEQEBdYk+u3T01pVsPrkj943T1aJAsw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.4':
     resolution: {integrity: sha512-ZfGtcp2xS51iG79c6Vhw9CWqQC8l2Ot8dygxoDoIQPTat/Ov3qAa8qpxSrtAEAJW+UjTXc4yxCjNfxm4h6Xm2A==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.4':
     resolution: {integrity: sha512-8hDVvW9eu4yHWnjaOOR8kHVrew1iIX+MUgwxSuH2XyYeNRtLUe4VNioSqbNkB7ZYQJj9rUTT4PyRscyk2PXFKA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.4':
     resolution: {integrity: sha512-lU0aA5L8QTlfKjpDCEFOZsTYGn3AEiO6db8W5aQDxj0nQkVrZWmN3ZP9sYKWJdtq3PWPhUNlqehWyXpYDcI9Sg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.4':
     resolution: {integrity: sha512-33QL6ZO/qpRyG7woB/HUALz28WnTMI2W1jgX3Nu2bypqLIKx/QKMILLJzJjI+SIbvXdG9fUnmrxR7vbi1sTBeA==}
@@ -2342,56 +2368,67 @@ packages:
     resolution: {integrity: sha512-PsNAbcyv9CcecAUagQefwX8fQn9LQ4nZkpDboBOttmyffnInRy8R8dSg6hxxl2Re5QhHBf6FYIDhIj5v982ATQ==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.52.5':
     resolution: {integrity: sha512-Fw4tysRutyQc/wwkmcyoqFtJhh0u31K+Q6jYjeicsGJJ7bbEq8LwPWV/w0cnzOqR2m694/Af6hpFayLJZkG2VQ==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.52.5':
     resolution: {integrity: sha512-a+3wVnAYdQClOTlyapKmyI6BLPAFYs0JM8HRpgYZQO02rMR09ZcV9LbQB+NL6sljzG38869YqThrRnfPMCDtZg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.52.5':
     resolution: {integrity: sha512-AvttBOMwO9Pcuuf7m9PkC1PUIKsfaAJ4AYhy944qeTJgQOqJYJ9oVl2nYgY7Rk0mkbsuOpCAYSs6wLYB2Xiw0Q==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.52.5':
     resolution: {integrity: sha512-DkDk8pmXQV2wVrF6oq5tONK6UHLz/XcEVow4JTTerdeV1uqPeHxwcg7aFsfnSm9L+OO8WJsWotKM2JJPMWrQtA==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.52.5':
     resolution: {integrity: sha512-W/b9ZN/U9+hPQVvlGwjzi+Wy4xdoH2I8EjaCkMvzpI7wJUs8sWJ03Rq96jRnHkSrcHTpQe8h5Tg3ZzUPGauvAw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.52.5':
     resolution: {integrity: sha512-sjQLr9BW7R/ZiXnQiWPkErNfLMkkWIoCz7YMn27HldKsADEKa5WYdobaa1hmN6slu9oWQbB6/jFpJ+P2IkVrmw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.52.5':
     resolution: {integrity: sha512-hq3jU/kGyjXWTvAh2awn8oHroCbrPm8JqM7RUpKjalIRWWXE01CQOf/tUNWNHjmbMHg/hmNCwc/Pz3k1T/j/Lg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.52.5':
     resolution: {integrity: sha512-gn8kHOrku8D4NGHMK1Y7NA7INQTRdVOntt1OCYypZPRt6skGbddska44K8iocdpxHTMMNui5oH4elPH4QOLrFQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.52.5':
     resolution: {integrity: sha512-hXGLYpdhiNElzN770+H2nlx+jRog8TyynpTVzdlc6bndktjKWyZyiCsuDAlpd+j+W+WNqfcyAWz9HxxIGfZm1Q==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.52.5':
     resolution: {integrity: sha512-arCGIcuNKjBoKAXD+y7XomR9gY6Mw7HnFBv5Rw7wQRvwYLR7gBAgV7Mb2QTyjXfTveBNFAtPt46/36vV9STLNg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openharmony-arm64@4.52.5':
     resolution: {integrity: sha512-QoFqB6+/9Rly/RiPjaomPLmR/13cgkIGfA40LHly9zcH1S0bN2HVFYk3a1eAyHQyjs3ZJYlXvIGtcCs5tko9Cw==}
@@ -2474,24 +2511,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.16':
     resolution: {integrity: sha512-H81UXMa9hJhWhaAUca6bU2wm5RRFpuHImrwXBUvPbYb+3jo32I9VIwpOX6hms0fPmA6f2pGVlybO6qU8pF4fzQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.16':
     resolution: {integrity: sha512-ZGHQxDtFC2/ruo7t99Qo2TTIvOERULPl5l0K1g0oK6b5PGqjYMga+FcY1wIUnrUxY56h28FxybtDEla+ICOyew==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.16':
     resolution: {integrity: sha512-Oi1tAaa0rcKf1Og9MzKeINZzMLPbhxvm7rno5/zuP1WYmpiG0bEHq4AcRUiG2165/WUzvxkW4XDYCscZWbTLZw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.16':
     resolution: {integrity: sha512-B01u/b8LteGRwucIBmCQ07FVXLzImWESAIMcUU6nvFt/tYsQ6IHz8DmZ5KtvmwxD+iTYBtM1xwoGXswnlu9v0Q==}
@@ -2806,41 +2847,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -5032,24 +5081,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
@@ -7984,6 +8037,10 @@ snapshots:
       '@firebase/logger': 0.5.0
       '@firebase/util': 1.13.0
       tslib: 2.8.1
+
+  '@firebase/rules-unit-testing@5.0.0(firebase@12.4.0)':
+    dependencies:
+      firebase: 12.4.0
 
   '@firebase/storage-compat@0.4.0(@firebase/app-compat@0.5.4)(@firebase/app-types@0.9.3)(@firebase/app@0.14.4)':
     dependencies:


### PR DESCRIPTION
The OR clause `resource.data.submittedBy.source == 'automated'` in the
admin database create rule for /suggestions was both broken and
dangerous: on a create the existing `resource` is null, so the clause
was effectively dead. If Firestore semantics ever changed, the field
was self-declared and would let any authenticated caller impersonate
another user by setting `submittedBy.source = 'automated'`.

Drop the OR entirely. Automated/bot suggestions are written by Cloud
Functions via the Admin SDK, which bypasses these rules.

Adds integration tests under `functions/src/test/` using
`@firebase/rules-unit-testing` covering:
- success when submittedBy.userId == auth.uid
- denial when submittedBy.userId != auth.uid (with and without
  submittedBy.source == 'automated')
- denial for unauthenticated callers

Closes #52

https://claude.ai/code/session_016JFKS7iAamG91EvBJT7ghX