### PR TITLE
Clarify admin permission check hierarchy and remove email-based auth

### DIFF
--- a/functions/DEPLOYMENT-GUIDE.md
+++ b/functions/DEPLOYMENT-GUIDE.md
@@ -27,10 +27,26 @@ npm install
 ```bash
 # functions/.env.development
 NODE_ENV=development
-ADMIN_EMAILS=admin@example.com,dev@example.com
 ALLOWED_ORIGINS=chrome-extension://,moz-extension://,http://localhost
 ADMIN_ALLOWED_ORIGINS=http://localhost:3000,http://localhost:5173
+# Required only for granting the very first admin via the
+# `setAdminClaims` HTTP function with the `x-setup-key` header.
+INITIAL_ADMIN_SETUP_KEY=replace-with-a-strong-random-string
 ```
+
+#### Granting Admin Access
+
+Admin authorization is determined solely by the Firebase Auth `admin`
+custom claim (see `firebase/firestore-admin.rules`). To grant admin:
+
+```ts
+import {getAuth} from "firebase-admin/auth";
+await getAuth().setCustomUserClaims(uid, {admin: true});
+```
+
+For the bootstrap case (no admin exists yet), call the `setAdminClaims`
+HTTP function with the `x-setup-key: $INITIAL_ADMIN_SETUP_KEY` header.
+Subsequent admin grants must be made by an already-admin caller.
 
 #### Production Environment  
 Set via Firebase Functions config:
@@ -40,7 +56,6 @@ firebase functions:config:set \
   graphql.complexity_budget="300" \
   graphql.depth_limit="6" \
   graphql.rate_limit="120" \
-  admin.emails="admin@wgu-extension.com" \
   reddit.client_id="your_reddit_client_id" \
   reddit.client_secret="your_reddit_client_secret"
 ```

--- a/functions/src/http/set-admin-claims.ts
+++ b/functions/src/http/set-admin-claims.ts
@@ -78,18 +78,15 @@ export const setAdminClaims = onRequest(
           return;
         }
 
-        // Check if calling user has admin privileges
+        // Check if calling user has admin privileges. Bootstrap (granting
+        // the very first admin) is handled by the `x-setup-key` header
+        // checked above; everyone else must already hold the `admin`
+        // custom claim.
         if (!decodedToken.admin) {
-          const adminEmails = (process.env.ADMIN_EMAILS || "")
-            .split(",")
-            .map((e) => e.trim())
-            .filter(Boolean);
-          if (!adminEmails.includes(decodedToken.email || "")) {
-            response.status(403).json({
-              error: "Forbidden - Admin access required to grant admin privileges",
-            });
-            return;
-          }
+          response.status(403).json({
+            error: "Forbidden - Admin access required to grant admin privileges",
+          });
+          return;
         }
       }
 

--- a/functions/src/lib/auth-utils.ts
+++ b/functions/src/lib/auth-utils.ts
@@ -111,20 +111,11 @@ export async function authenticateRequest(request: CallableRequest | any): Promi
   const userId = decodedToken.uid;
   const userEmail = decodedToken.email || "";
 
-  // Check admin privileges
-  let isAdmin = false;
-
-  // Option 1: Custom claims
-  if (decodedToken.admin) {
-    isAdmin = true;
-  } else {
-    // Option 2: Admin email list
-    const adminEmails = (process.env.ADMIN_EMAILS || "")
-      .split(",")
-      .map((e) => e.trim())
-      .filter(Boolean);
-    isAdmin = adminEmails.includes(userEmail);
-  }
+  // Admin status is determined solely by the Firebase Auth `admin` custom
+  // claim, matching `firebase/firestore-admin.rules`. To grant admin, use
+  // `admin.auth().setCustomUserClaims(uid, { admin: true })` (e.g. via the
+  // `setAdminClaims` HTTP function).
+  const isAdmin = decodedToken.admin === true;
 
   return {
     userId,

--- a/functions/src/lib/auth.ts
+++ b/functions/src/lib/auth.ts
@@ -1,5 +1,6 @@
 import * as admin from "firebase-admin";
 import {getAuth} from "firebase-admin/auth";
+import {adminDb} from "./firebase-admin-db.js";
 
 export interface AdminUser {
   uid: string;
@@ -29,10 +30,12 @@ export async function verifyAdminAuth(token: string): Promise<AdminUser> {
     // Verify the Firebase Auth token
     const decodedToken = await admin.auth().verifyIdToken(token);
 
-    // Check if the user has admin permissions
-    // Canonical signal is the Firebase Auth `admin` custom claim, with the
-    // Firestore `admin_users` collection as a secondary mechanism.
-    const isAdmin = await checkAdminPermissions(decodedToken.uid);
+    // Check if the user has admin permissions.
+    // Fast path: the decoded token already carries the canonical `admin`
+    // custom claim, so we can avoid the extra `getUser` round-trip when set.
+    // Otherwise fall back to the secondary `admin_users` collection check.
+    const isAdmin =
+      decodedToken.admin === true || (await checkAdminPermissions(decodedToken.uid));
 
     if (!isAdmin) {
       throw new Error("User does not have admin permissions");
@@ -75,9 +78,9 @@ async function checkAdminPermissions(uid: string): Promise<boolean> {
     console.warn("Failed to check custom claims:", error);
   }
 
-  // Method 2: Check Firestore admin_users collection
+  // Method 2: Check Firestore admin_users collection (in the admin database)
   try {
-    const adminDoc = await admin.firestore()
+    const adminDoc = await adminDb
       .collection("admin_users")
       .doc(uid)
       .get();

--- a/functions/src/lib/auth.ts
+++ b/functions/src/lib/auth.ts
@@ -30,8 +30,9 @@ export async function verifyAdminAuth(token: string): Promise<AdminUser> {
     const decodedToken = await admin.auth().verifyIdToken(token);
 
     // Check if the user has admin permissions
-    // This could be stored in custom claims, Firestore, or environment config
-    const isAdmin = await checkAdminPermissions(decodedToken.uid, decodedToken.email);
+    // Canonical signal is the Firebase Auth `admin` custom claim, with the
+    // Firestore `admin_users` collection as a secondary mechanism.
+    const isAdmin = await checkAdminPermissions(decodedToken.uid);
 
     if (!isAdmin) {
       throw new Error("User does not have admin permissions");
@@ -51,18 +52,20 @@ export async function verifyAdminAuth(token: string): Promise<AdminUser> {
 }
 
 /**
- * Check if a user has admin permissions
- * This is a placeholder implementation - in production, you might:
- * 1. Check Firebase Auth custom claims
- * 2. Query a Firestore admin users collection
- * 3. Check against a hardcoded list of admin emails in environment variables
- * 4. Use a more sophisticated RBAC system
+ * Check if a user has admin permissions.
+ *
+ * Canonical signal is the Firebase Auth custom claim `admin === true`,
+ * which matches `firebase/firestore-admin.rules`. The `admin_users`
+ * Firestore collection is checked as a secondary mechanism for
+ * collection-managed admins with an `active` flag.
+ *
+ * To grant admin access, set the custom claim with:
+ *   admin.auth().setCustomUserClaims(uid, { admin: true })
  * @param {string} uid - The user ID to check
- * @param {string} email - The user email (optional)
  * @return {Promise<boolean>} Whether the user has admin permissions
  */
-async function checkAdminPermissions(uid: string, email?: string): Promise<boolean> {
-  // Method 1: Check Firebase Auth custom claims
+async function checkAdminPermissions(uid: string): Promise<boolean> {
+  // Method 1: Check Firebase Auth custom claims (canonical)
   try {
     const userRecord = await admin.auth().getUser(uid);
     if (userRecord.customClaims?.admin === true) {
@@ -72,13 +75,7 @@ async function checkAdminPermissions(uid: string, email?: string): Promise<boole
     console.warn("Failed to check custom claims:", error);
   }
 
-  // Method 2: Check environment variable for admin emails
-  const adminEmails = process.env.ADMIN_EMAILS?.split(",").map((e) => e.trim()) || [];
-  if (email && adminEmails.includes(email)) {
-    return true;
-  }
-
-  // Method 3: Check Firestore admin collection (optional)
+  // Method 2: Check Firestore admin_users collection
   try {
     const adminDoc = await admin.firestore()
       .collection("admin_users")

--- a/functions/src/lib/auth.ts
+++ b/functions/src/lib/auth.ts
@@ -55,30 +55,20 @@ export async function verifyAdminAuth(token: string): Promise<AdminUser> {
 }
 
 /**
- * Check if a user has admin permissions.
+ * Secondary admin permission check.
  *
- * Canonical signal is the Firebase Auth custom claim `admin === true`,
- * which matches `firebase/firestore-admin.rules`. The `admin_users`
- * Firestore collection is checked as a secondary mechanism for
- * collection-managed admins with an `active` flag.
+ * The canonical signal is the Firebase Auth custom claim `admin === true`
+ * read directly from the decoded ID token in `verifyAdminAuth`. This
+ * function is the fallback path for collection-managed admins: an entry
+ * in the `admin_users` collection (in the `admin` database) with an
+ * `active === true` flag.
  *
- * To grant admin access, set the custom claim with:
+ * To grant admin access via custom claim, use:
  *   admin.auth().setCustomUserClaims(uid, { admin: true })
  * @param {string} uid - The user ID to check
  * @return {Promise<boolean>} Whether the user has admin permissions
  */
 async function checkAdminPermissions(uid: string): Promise<boolean> {
-  // Method 1: Check Firebase Auth custom claims (canonical)
-  try {
-    const userRecord = await admin.auth().getUser(uid);
-    if (userRecord.customClaims?.admin === true) {
-      return true;
-    }
-  } catch (error) {
-    console.warn("Failed to check custom claims:", error);
-  }
-
-  // Method 2: Check Firestore admin_users collection (in the admin database)
   try {
     const adminDoc = await adminDb
       .collection("admin_users")


### PR DESCRIPTION
## Summary
This PR refines the admin authentication logic to establish a clear, documented hierarchy for checking admin permissions and removes the environment variable-based email allowlist approach.

## Key Changes
- **Clarified permission check hierarchy**: Established Firebase Auth custom claims as the canonical signal for admin status, with Firestore `admin_users` collection as a secondary mechanism
- **Removed email-based authentication**: Eliminated the `ADMIN_EMAILS` environment variable approach, which was less secure and harder to manage
- **Simplified function signature**: Removed the `email` parameter from `checkAdminPermissions()` since it's no longer needed
- **Improved documentation**: Updated JSDoc comments to clearly explain the two-tier admin permission system and provide guidance on granting admin access via `setCustomUserClaims()`

## Implementation Details
- The Firebase Auth custom claim `admin === true` is now the primary and recommended way to grant admin access
- The Firestore `admin_users` collection with an `active` flag serves as a fallback mechanism for collection-managed admins
- Updated comments reference alignment with `firebase/firestore-admin.rules` for consistency
- Added explicit instructions in the JSDoc for how to grant admin access using the Firebase Admin SDK

https://claude.ai/code/session_011j7a3gzqFFpUSeZmPBV6oy